### PR TITLE
Add meeting information to the maintainer onboarding doc

### DIFF
--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -63,3 +63,9 @@ Being that contributions will vary in substance and frequency, the Core team wil
         - If no one has reviewed the PR, you are welcome to post it in the #review-requests channel to bring it to everyone's attention.
         - If the contributor has made the requested changes without requesting another review, you should request it for them on GitHub.
     - If a PR was made by another maintainer only approve it, don't merge it. On the team we merge our own PRs.
+
+### Attend Meetings
+
+- Subscribe to the group Google Calendar (link pinned in the maintainer-discussions channel of the discord)
+- Meetings are generally held twice a month
+- Attendance is not *required* but is strongly encouraged whenever you're able to attend.


### PR DESCRIPTION
**1. Because:**
The maintainer onboarding document makes no mention of the meetings
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->


**2. This PR:**
Adds information about the meetings
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

