### PR TITLE
Added 2FA setup link and requirement to the on-boarding docs for maints/mods.

### DIFF
--- a/onboarding/chat-moderators.md
+++ b/onboarding/chat-moderators.md
@@ -7,6 +7,10 @@ Moderators are representatives of TOP's community who assist with moderating the
 
 Moderators of the TOP community are *not* maintainers, and should not act as such. Moderators should not attempt to speak on the behalf of the maintainer team regarding plans for the curriculum or the platform outside of Discord. This does not mean moderators cannot provide their own ideas, suggestions, etc, in our `#contribution-suggestions-bugs-discussions` channel or leave general comments/questions on open issues in our repos. There is a fine line between "Would this approach also work?" and "You should update this to follow this approach instead", for example.
 
+## Settings 
+
+- Please ensure you have 2FA authentication enabled so you will have access to the moderation options for the discord. You can find the discord guide for 2FA [here](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
+
 ### Admission and Removal of Role
 
 Moderators, and those wishing to be considered for the Moderator role, are expected to have a history of regular and positive contributions to The Odin Project Discord community. Chat moderators are members of the community that illustrate and personify what it means to create a positive impact by abiding by the rules, extending help to others in regards to the community,  having a willingness to hold both themselves and others accountable within the community, and motivating others to create a positive environment.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -8,6 +8,8 @@ Maintainers are representatives of The Odin Project community who assist with mo
 
 - Please ensure you have 2FA authentication enabled so if a situation arises in which you need to moderate you will be able to do so. You can find the discord guide for 2FA [here](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
 
+- You should ensure you have 2FA authentication enabled for Github to keep your account secure. _Please ensure you follow the guide [here](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)_ to ensure you set up 2FA properly.
+
 ### Admission and Removal of Role
 
 Maintainers, and those wishing to be considered for the Maintainer role, are expected to have a record of regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -4,6 +4,10 @@
 
 Maintainers are representatives of The Odin Project community who assist with moderating the official Discord server and the management of processes on the Github account.
 
+## Settings 
+
+- Please ensure you have 2FA authentication enabled so if a situation arises in which you need to moderate you will be able to do so. You can find the discord guide for 2FA [here](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
+
 ### Admission and Removal of Role
 
 Maintainers, and those wishing to be considered for the Maintainer role, are expected to have a record of regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.


### PR DESCRIPTION
**1. Because:**

2FA authentication is needed for individuals to moderate and access moderation options however, this is not stated in the onboarding docs for maintainers or moderators. This PR adds a small section with a link to the setup guide by discord and adds a section on 2FA for both maintainers and moderators onboardings docs stating they need to ensure they have a 2FA setup.
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Closes #XXXXX


**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

