### PR TITLE
Update Moderation_Matrix.md

### DIFF
--- a/MODERATION/Moderation-Matrix.md
+++ b/MODERATION/Moderation-Matrix.md
@@ -20,7 +20,7 @@ Minor violations such as:
   - Enforcement of any of the rules instead of notifying moderators (see example below)
   - Please leave moderation action to the moderators
   - Use ModMail to report rule breaking or if you see something you’re unsure about in the community
-- Asking for advice/help on projects unrelated to The Odin Project, or asking about topics unrelated to our Discord channels
+- Asking for advice/help on homework or personal projects, even if the topic is covered by our curriculum
 - Mild unprofessionalism:
   - Drug related conversation 
   - Treating others on the server disrespectfully


### PR DESCRIPTION
**1. Because:**
Currently, the moderation matrix states that all questions and advice should stay within the scope of our curriculum - with the matrix wording for the corresponding infraction issuing zaps for non-TOP questions regardless of context. 

In the spirit of creating a more welcoming community, I believe learners should be allowed to ask general queries - such as where they could possibly find resources to answer a question. 

**2. This PR:**
This proposed change updates the wording of the Matrix to have the 1 zap offense be less all-encompassing and more specific to homework/personal project assistance.

