### PR TITLE
Add form to staff reporting procedure

### DIFF
--- a/staff-guidelines.md
+++ b/staff-guidelines.md
@@ -1,29 +1,31 @@
-# Social Contract
+# Staff Guidelines
 
-This social contract is created, altered, and maintained by the team and should be reviewed regularly. It’s our by-laws. People need to be held accountable to these and anyone joining needs to accept the contract and understand that they will be called out for not following it. 
+## Social Contract
 
-Following social contract should be one of the considerations of “performance grading” for staff. 
+This social contract is created, altered, and maintained by the team and should be reviewed regularly. It’s our by-laws. People need to be held accountable to these and anyone joining needs to accept the contract and understand that they will be called out for not following it.
 
--  These behaviors and expectations extend to private messaging and discussions within privileged access channels 
-- Remember there is a real human being on the other side of the screen. 
+Following social contract should be one of the considerations of “performance grading” for staff.
+
+-  These behaviors and expectations extend to private messaging and discussions within privileged access channels
+- Remember there is a real human being on the other side of the screen.
 - Assume positive intent.
 - Be honest, transparent, and respectful.
 - Be fair, be kind, and be gracious.
-- Keep the mission of The Odin Project above your personal ambitions. 
-- Consider your peers as the professionals they are. Your experience does not trump others. 
-- Embrace the unique differences on the team and learn from each other to be a better staff member, and even beyond TOP. 
-- Be aware of difficulties of typed communication where tone and voice are hard to interpret. Keep use of sarcasm, emojis, slang to a minimum during more serious discussions. 
+- Keep the mission of The Odin Project above your personal ambitions.
+- Consider your peers as the professionals they are. Your experience does not trump others.
+- Embrace the unique differences on the team and learn from each other to be a better staff member, and even beyond TOP.
+- Be aware of difficulties of typed communication where tone and voice are hard to interpret. Keep use of sarcasm, emojis, slang to a minimum during more serious discussions.
 - Healthy conflict where others opinions are heard is welcome, but we should avoid it turning into personal fighting, insulting or sarcasm.
-- Stay true to your promises. Communicate clearly when you can’t keep up or deliver what is promised. No shame in that. 
+- Stay true to your promises. Communicate clearly when you can’t keep up or deliver what is promised. No shame in that.
 - Avoid focusing on an individual. Focus on a problem and how it can be solved as a team.
-- Don’t continuously complain about issues without proposing a solution. 
+- Don’t continuously complain about issues without proposing a solution.
 - Communicate prolonged absences as defined per role expectations.
 - Opinions change, people should respect that but also be ready to defend yourself when pressed on the topic, but it must all be done respectfully.
 - People have a right to their opinions, if the explanation of their opinion is not to your liking, you must still respect that outcome. Defer to voting if necessary
 
----
 
-# Communication    
+## Communication
+
 - Communicate absences. For different reasons, related to work, studies, family, etc. there will be periods of time where a staff member can not commit to the demands of TOP and its community, either as much as one would like or as much as is needed. However, this should be the exception, not the rule.
 - Propose changes to function or form of The Odin Project
   - Curriculum Changes
@@ -33,20 +35,21 @@ Following social contract should be one of the considerations of “performance 
   - Etc.
 - Communications should happen on a semi-regular cadence
 
----
 
-# Procedure for reporting a concern with an Odin Staff Member.
+## Procedure for reporting a concern with an Odin Staff Member.
 
-Odin staff members include all members of the Core, Maintainer and Moderators Teams. Concerns can include, but should not be limited to infractions against the Social Contract, team expectations, and Discord rule infractions.
+Odin staff members include all members of the Core, Maintainer and Moderator teams. Concerns include but are not limited to infractions against the Social Contract, team expectations, and Discord rule infractions.
 
-## How to make a report
+### How to make a report
+
+There are two options to make a report. You can choose the option that makes the most sense for the specific situation or the one that makes you the most comfortable.
 
 1. Send a Direct Message to at least 2 non-offending Core members
 2. Submit an anonymous or nonanonymous [form](https://dyno.gg/form/aef8feab) that is visible to all Core members.
 
 Regardless of where a report originates, each report will all be handled by non-offending Core members.
 
-## Follow-up for nonanonymous reports
+### Follow-up for nonanonymous reports
 
 - The reporter should receive confirmation that the report has been received in a timely manner (within 24 hours).
 - If you do not receive this confirmation, it is acceptable and appropriate to either ask for a follow-up or send the report to another staff member.

--- a/staff-guidelines.md
+++ b/staff-guidelines.md
@@ -32,3 +32,23 @@ Following social contract should be one of the considerations of “performance 
   - Initiatives (e.g. Gamejams, TOPathons, Fireside chats)
   - Etc.
 - Communications should happen on a semi-regular cadence
+
+---
+
+# Procedure for reporting a concern with an Odin Staff Member.
+
+Odin staff members include all members of the Core, Maintainer and Moderators Teams. Concerns can include, but should not be limited to infractions against the Social Contract, team expectations, and Discord rule infractions.
+
+## How to make a report
+
+1. Send a Direct Message to at least 2 non-offending Core members
+2. Submit an anonymous or nonanonymous [form](https://dyno.gg/form/aef8feab) that is visible to all Core members.
+
+Regardless of where a report originates, each report will all be handled by non-offending Core members.
+
+## Follow-up for nonanonymous reports
+
+- The reporter should receive confirmation that the report has been received in a timely manner (within 24 hours).
+- If you do not receive this confirmation, it is acceptable and appropriate to either ask for a follow-up or send the report to another staff member.
+- The non-offending Core members may create a group DM with the reporter to ask clarifying questions or request evidence of the reported infraction.
+- The reporter will be given confirmation that their report has been addressed and appropriately escalated. This confirmation will not include extensive details of actions taken.


### PR DESCRIPTION
**1. Because:**
This procedure belongs in the staff guidelines, instead of the core guidelines. In addition, we've created a form that can be submitted anonymously, so I updated the wording of this procedure to reflect it.

Previously created PR for core guidelines:
https://github.com/TheOdinProject/top-meta/pull/182

**2. This PR:**
* Added two sub-sections to make the information more readable
* Added the form that can be submitted anonymously


**3. Additional Information:**


