### PR TITLE
FAQ: Change link to a more descriptive title

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -99,7 +99,7 @@ Read our [guide on helping others solve coding problems](https://www.theodinproj
 
 **How should I ask questions?**
 
-[Read this](https://www.theodinproject.com/guides/community/how_to_ask).
+[Read our page on asking technical questions](https://www.theodinproject.com/guides/community/how_to_ask).
 
 **What books should I read/do you recommend?** 
 


### PR DESCRIPTION
## Because
- The current title for the link under how to ask questions is a simple "read this", without any indication where the link will take you


## This PR
- Changes it to indicate that the link goes to https://www.theodinproject.com/guides/community/how_to_ask