### PR TITLE
Add top-contributor to list of roles

### DIFF
--- a/about/discord-roles.md
+++ b/about/discord-roles.md
@@ -19,6 +19,7 @@ We all know that as a Server Booster you receive a special role in the server. I
 
 These roles have **no moderation** privileges.
 
+- **top-contributor** - folks that have regularly contributed to our public repositories: `curriculum`, `theodinproject`, `odin-bot-v2`, or one of our many exercise repos. 
 - **club-40** - folks that have been around TOP for a while and have most often helped out other learners in the channels. This role is maintained by the Odin Bot and this status is achieved by reaching 40 points. 
 - **cah-crew** and **jam participant** - community events focused on providing opportunities for team work. Keep an eye on the #announcements for more events!
 - **...-book-club** - participants in our book clubs, such as YDKJS book series. 


### PR DESCRIPTION
## Because
When we add a new role, we need to make sure to add an explanation to inform our community 


## This PR
* add an explanation for the `top-contributor` role


## Issue
Relates to https://github.com/TheOdinProject/staff/issues/13

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

