### PR TITLE
Chore: repoint contributing links to .github/CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/style-guide.md
+++ b/.github/ISSUE_TEMPLATE/style-guide.md
@@ -8,11 +8,11 @@ assignees: ''
 ---
 
 # Lesson Name
-This issue is part of the Style Guide Community Project, a way of offering members of The Odin Project community a chance to contribute to our curriculum. Users who wish to take part and contribute to any Style Guide issues should have thoroughly read the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md) and [The Odin Project contributing guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md).
-  
+This issue is part of the Style Guide Community Project, a way of offering members of The Odin Project community a chance to contribute to our curriculum. Users who wish to take part and contribute to any Style Guide issues should have thoroughly read the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md) and [The Odin Project contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md).
+
 ## Description of Issue
 This is a brief description of the issue.
-  
+
 ## Acceptance Criteria
 This is the definition of success. If the requirements here are not met, the work effort is not complete.
 - [ ] Any requirements noted in the issue description above are met.


### PR DESCRIPTION
## Because
- We are centralizing to https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md as the single source of truth for CONTRIBUTING.md


## This PR
- Changes all https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md links to https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md


## Issue

Part of TheOdinProject/theodinproject#3901

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section