### PR TITLE
Fix: update links to rules

### DIFF
--- a/MODERATION/Moderation-Matrix.md
+++ b/MODERATION/Moderation-Matrix.md
@@ -1,5 +1,5 @@
 # Moderation Matrix
 
-Our moderation matrix is now our rules. You may view them [on our website](https://www.theodinproject.com/community_rules) or in Discord's #rules channel. 
+Our moderation matrix is now our rules. You may view them [on our website](https://www.theodinproject.com/guides/community/rules) or in Discord's #rules channel. 
 
-If you would like to suggest a change, you can make a pull request [on our website's repository](https://github.com/TheOdinProject/theodinproject/blob/main/app/views/static_pages/dashboard_steps/community_rules.md)
+If you would like to suggest a change, you can make a pull request [on our website's repository](https://github.com/TheOdinProject/theodinproject/blob/main/app/views/guides/community/rules.html.erb)


### PR DESCRIPTION
## Because
- The page containing the rules as well as the file holding them has moved


## This PR
- Updates the links to point to the correct location