### PR TITLE
Add community rules in markdown

### DIFF
--- a/community-rules.md
+++ b/community-rules.md
@@ -8,7 +8,7 @@ We expect everyone to handle themselves in a respectful manner and follow the sp
 
 When a rule has been broken, the moderators will assume everyone had positive intentions and will try to de-escalate the situation by having a conversation to clarify the expectations of our rules. If you are contacted by our moderation team, please do not take it personally or become argumentative. We realize that we have higher standards than the average Discord server to ensure the safety and wellbeing of our entire community.
 
-### <span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Do
+### &#9989; Do
 - Discuss topics that are safe and welcoming for everyone
 - Ask questions about content or projects in our curriculum
 - Ask questions about the tool recommended in our curriculum
@@ -20,7 +20,7 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Report misconduct to ModMail
 - Act professionally and treat everyone with respect
 
-### <span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Don't
+### &#10060; Don't
 - Discuss topics that can be harmful or divisive
 - Ask for help on personal projects or homework
 - Suggest tools that are not recommended in our curriculum
@@ -33,37 +33,37 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Act unprofessionally or treat anyone disrespectfully
 
 ### Discuss topics that are safe and welcoming for everyone
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Discuss topics that are relevant to our curriculum or have an off-topic channel.
+&#9989; Discuss topics that are relevant to our curriculum or have an off-topic channel.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not discuss any unrelated topics that can be divisive or harmful, such as illegal activities, politics, religion, relationships, mental health, medical conditions, medicine, homeopathic or other home remedies, etc.
+&#10060; Do not discuss any unrelated topics that can be divisive or harmful, such as illegal activities, politics, religion, relationships, mental health, medical conditions, medicine, homeopathic or other home remedies, etc.
 
 ### Ask questions about content or projects in our curriculum
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> The purpose of this server is to support people when they run into issues doing our curriculum. This allows our volunteers to know the exact scope of your problem and correct any poor advice. In addition, this limited scope helps us identify areas in our curriculum that we need to improve.
+&#9989; The purpose of this server is to support people when they run into issues doing our curriculum. This allows our volunteers to know the exact scope of your problem and correct any poor advice. In addition, this limited scope helps us identify areas in our curriculum that we need to improve.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not ask for advice/help on homework or personal projects, even if the topic is covered by our curriculum. Instead, research other servers/communities that offer general programming help.
+&#10060; Do not ask for advice/help on homework or personal projects, even if the topic is covered by our curriculum. Instead, research other servers/communities that offer general programming help.
 
 ### Ask questions about the tools recommended in our curriculum
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> This community is run by the same volunteers who maintain the curriculum and they created this server as a way to support people when they run into issues with our recommendations.
+&#9989; This community is run by the same volunteers who maintain the curriculum and they created this server as a way to support people when they run into issues with our recommendations.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not suggest tools that are outside of the curriculum's recommendations, such as using Windows, WSL, etc, because our committed volunteers are not equipped to support these additional tools. You are welcome to use them, but do not suggest them to others.
+&#10060; Do not suggest tools that are outside of the curriculum's recommendations, such as using Windows, WSL, etc, because our committed volunteers are not equipped to support these additional tools. You are welcome to use them, but do not suggest them to others.
 
 ### Ask questions in public channels for anyone to answer
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Ask questions in public channels because everyone in this community shares the responsibility to answer questions and others can learn from reading the conversation. It is unfair to expect specific people to answer your question.
+&#9989; Ask questions in public channels because everyone in this community shares the responsibility to answer questions and others can learn from reading the conversation. It is unfair to expect specific people to answer your question.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not send direct messages, friend requests, or ping another user without prior consent.
+&#10060; Do not send direct messages, friend requests, or ping another user without prior consent.
 
 ### Ask your question in only one channel
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> After asking your question in one channel, allow at least 30 minutes for a reply. While you are waiting, make sure that you posted in the most relevant channel, provided a detailed question, and continue trouble-shooting. It is recommended to edit your post with the results of things you have tried. If your post gets buried, you may repost your question, otherwise, you may direct people to your question in a more active channel.
+&#9989; After asking your question in one channel, allow at least 30 minutes for a reply. While you are waiting, make sure that you posted in the most relevant channel, provided a detailed question, and continue trouble-shooting. It is recommended to edit your post with the results of things you have tried. If your post gets buried, you may repost your question, otherwise, you may direct people to your question in a more active channel.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not post the same question in multiple channels.
+&#10060; Do not post the same question in multiple channels.
 
 ### Help others by guiding them to the solution in a public 1:1 conversation
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Our community values guiding a person to the solution because it empowers them with more practical skills to apply the next time they run into a problem.
+&#9989; Our community values guiding a person to the solution because it empowers them with more practical skills to apply the next time they run into a problem.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not provide the answer or intrude into a public 1:1 conversation with a different answer. If the guidance is incorrect, you may politely state that there might be some confusion and ask permission to help clarify the issue.
+&#10060; Do not provide the answer or intrude into a public 1:1 conversation with a different answer. If the guidance is incorrect, you may politely state that there might be some confusion and ask permission to help clarify the issue.
 
 ### Make it easy for others to help you by asking a detailed question
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Ask detailed questions by following our [How to Ask Technical Questions](https://www.theodinproject.com/guides/community/how_to_ask) guide. Since your post will be fairly long, use shift + enter to add new lines between paragraphs. A detailed question should contain the following elements:
+&#9989; Ask detailed questions by following our [How to Ask Technical Questions](https://www.theodinproject.com/guides/community/how_to_ask) guide. Since your post will be fairly long, use shift + enter to add new lines between paragraphs. A detailed question should contain the following elements:
 
 - Link to the lesson/project in the curriculum
 - Your current code or pseudo code
@@ -71,7 +71,7 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Describe what you are expecting
 - Summarize what you have tried
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Avoid asking low effort questions because it puts too much responsibility on others to properly guide you to the answer. For example:
+&#10060; Avoid asking low effort questions because it puts too much responsibility on others to properly guide you to the answer. For example:
 
 - Not providing enough details or context
 - Asking questions that can be easily googled or not doing your own research first
@@ -80,9 +80,9 @@ When a rule has been broken, the moderators will assume everyone had positive in
 **We take this rule very seriously because repeatedly asking low effort questions causes a drain on our community of volunteers.**
 
 ### Share resources that are relevant to our curriculum
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> When sharing resources that are relevant to our curriculum, add surrounding context, such as where you are in the curriculum, what exactly you found helpful, a code example, etc. Remember that our curriculum is open source, so you are encouraged to make a pull request to add it to the curriculum.
+&#9989; When sharing resources that are relevant to our curriculum, add surrounding context, such as where you are in the curriculum, what exactly you found helpful, a code example, etc. Remember that our curriculum is open source, so you are encouraged to make a pull request to add it to the curriculum.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> The following resources are not relevant to our curriculum and should not be posted. If you have extraordinary circumstances that you would like to be considered, you are welcome to message ModMail for permission:
+&#10060; The following resources are not relevant to our curriculum and should not be posted. If you have extraordinary circumstances that you would like to be considered, you are welcome to message ModMail for permission:
 
 - Link to a resource you created for personal or monetary gain
 - Request to have people fill out a survey
@@ -92,14 +92,14 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Job posts or recruitment
 
 ### Report misconduct to ModMail
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Use Modmail to report misconduct, private harassment by a community member, or if anyone makes you or others feel unsafe, uncomfortable, or unwelcome in our community.
+&#9989; Use Modmail to report misconduct, private harassment by a community member, or if anyone makes you or others feel unsafe, uncomfortable, or unwelcome in our community.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not correct or confront another user about their misconduct. We know you mean well, but this will often make the situation worse.
+&#10060; Do not correct or confront another user about their misconduct. We know you mean well, but this will often make the situation worse.
 
 ### Act professionally and treat everyone with respect
-<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> The culture of this community is very similar to the professional workplace messaging apps of our volunteer team. Learning how to respectfully interact with others from around the world will prepare you to interact with your future teammates.
+&#9989; The culture of this community is very similar to the professional workplace messaging apps of our volunteer team. Learning how to respectfully interact with others from around the world will prepare you to interact with your future teammates.
 
-<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> We have zero tolerance for disrespect. Therefore, the following behaviors will result in a ban from our server:
+&#10060; We have zero tolerance for disrespect. Therefore, the following behaviors will result in a ban from our server:
 
 - Bigotry, such as racism, homophobia, hate speech, etc
 - NSFW or other highly offensive images in posts, profile pictures, or username

--- a/community-rules.md
+++ b/community-rules.md
@@ -32,35 +32,49 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Correct or confront another user about their misconduct
 - Act unprofessionally or treat anyone disrespectfully
 
+[rule-name]: # (safe-topics)
+
 ### Discuss topics that are safe and welcoming for everyone
 &#9989; Discuss topics that are relevant to our curriculum or have an off-topic channel.
 
 &#10060; Do not discuss any unrelated topics that can be divisive or harmful, such as illegal activities, politics, religion, relationships, mental health, medical conditions, medicine, homeopathic or other home remedies, etc.
+
+[rule-name]: # (curriculum-content)
 
 ### Ask questions about content or projects in our curriculum
 &#9989; The purpose of this server is to support people when they run into issues doing our curriculum. This allows our volunteers to know the exact scope of your problem and correct any poor advice. In addition, this limited scope helps us identify areas in our curriculum that we need to improve.
 
 &#10060; Do not ask for advice/help on homework or personal projects, even if the topic is covered by our curriculum. Instead, research other servers/communities that offer general programming help.
 
+[rule-name]: # (curriculum-tools)
+
 ### Ask questions about the tools recommended in our curriculum
 &#9989; This community is run by the same volunteers who maintain the curriculum and they created this server as a way to support people when they run into issues with our recommendations.
 
 &#10060; Do not suggest tools that are outside of the curriculum's recommendations, such as using Windows, WSL, etc, because our committed volunteers are not equipped to support these additional tools. You are welcome to use them, but do not suggest them to others.
+
+[rule-name]: # (public-questions)
 
 ### Ask questions in public channels for anyone to answer
 &#9989; Ask questions in public channels because everyone in this community shares the responsibility to answer questions and others can learn from reading the conversation. It is unfair to expect specific people to answer your question.
 
 &#10060; Do not send direct messages, friend requests, or ping another user without prior consent.
 
+[rule-name]: # (one-channel)
+
 ### Ask your question in only one channel
 &#9989; After asking your question in one channel, allow at least 30 minutes for a reply. While you are waiting, make sure that you posted in the most relevant channel, provided a detailed question, and continue trouble-shooting. It is recommended to edit your post with the results of things you have tried. If your post gets buried, you may repost your question, otherwise, you may direct people to your question in a more active channel.
 
 &#10060; Do not post the same question in multiple channels.
 
+[rule-name]: # (public-help)
+
 ### Help others by guiding them to the solution in a public 1:1 conversation
 &#9989; Our community values guiding a person to the solution because it empowers them with more practical skills to apply the next time they run into a problem.
 
 &#10060; Do not provide the answer or intrude into a public 1:1 conversation with a different answer. If the guidance is incorrect, you may politely state that there might be some confusion and ask permission to help clarify the issue.
+
+[rule-name]: # (detailed-question)
 
 ### Make it easy for others to help you by asking a detailed question
 &#9989; Ask detailed questions by following our [How to Ask Technical Questions](https://www.theodinproject.com/guides/community/how_to_ask) guide. Since your post will be fairly long, use shift + enter to add new lines between paragraphs. A detailed question should contain the following elements:
@@ -79,6 +93,8 @@ When a rule has been broken, the moderators will assume everyone had positive in
 
 **We take this rule very seriously because repeatedly asking low effort questions causes a drain on our community of volunteers.**
 
+[rule-name]: # (relevant-resources)
+
 ### Share resources that are relevant to our curriculum
 &#9989; When sharing resources that are relevant to our curriculum, add surrounding context, such as where you are in the curriculum, what exactly you found helpful, a code example, etc. Remember that our curriculum is open source, so you are encouraged to make a pull request to add it to the curriculum.
 
@@ -91,10 +107,14 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Fundraising or donation drives
 - Job posts or recruitment
 
+[rule-name]: # (modmail)
+
 ### Report misconduct to ModMail
 &#9989; Use Modmail to report misconduct, private harassment by a community member, or if anyone makes you or others feel unsafe, uncomfortable, or unwelcome in our community.
 
 &#10060; Do not correct or confront another user about their misconduct. We know you mean well, but this will often make the situation worse.
+
+[rule-name]: # (respect)
 
 ### Act professionally and treat everyone with respect
 &#9989; The culture of this community is very similar to the professional workplace messaging apps of our volunteer team. Learning how to respectfully interact with others from around the world will prepare you to interact with your future teammates.

--- a/community-rules.md
+++ b/community-rules.md
@@ -1,0 +1,116 @@
+## Community Rules
+
+Our Discord server is a very active community of people from all over the world and is moderated by a team of volunteers. Our moderation team has 3 different [roles](https://github.com/TheOdinProject/top-meta/blob/main/about/discord-roles.md): Core, Maintainer, and Moderator.
+
+Our moderation team is committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, neurodivergence, personal appearance, body, race, ethnicity, age, religion, nationality, or other similar characteristic.
+
+We expect everyone to handle themselves in a respectful manner and follow the spirit of our community rules.
+
+When a rule has been broken, the moderators will assume everyone had positive intentions and will try to de-escalate the situation by having a conversation to clarify the expectations of our rules. If you are contacted by our moderation team, please do not take it personally or become argumentative. We realize that we have higher standards than the average Discord server to ensure the safety and wellbeing of our entire community.
+
+### <span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Do
+- Discuss topics that are safe and welcoming for everyone
+- Ask questions about content or projects in our curriculum
+- Ask questions about the tool recommended in our curriculum
+- Ask questions in public channels for anyone to answer
+- Ask your question in only one channel
+- Help others by guiding them to the solution in a public 1:1 conversation
+- Make it easy for others to help you by asking a detailed question
+- Share resources that are relevant to our curriculum
+- Report misconduct to ModMail
+- Act professionally and treat everyone with respect
+
+### <span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Don't
+- Discuss topics that can be harmful or divisive
+- Ask for help on personal projects or homework
+- Suggest tools that are not recommended in our curriculum
+- Send direct messages, friend requests, or ping another user without prior consent
+- Ask your question in multiple channels
+- Intrude into a public 1:1 conversation by providing a different answer
+- Avoid asking low effort questions that are missing relevant details
+- Share resources that are not relevant to our curriculum
+- Correct or confront another user about their misconduct
+- Act unprofessionally or treat anyone disrespectfully
+
+### Discuss topics that are safe and welcoming for everyone
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Discuss topics that are relevant to our curriculum or have an off-topic channel.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not discuss any unrelated topics that can be divisive or harmful, such as illegal activities, politics, religion, relationships, mental health, medical conditions, medicine, homeopathic or other home remedies, etc.
+
+### Ask questions about content or projects in our curriculum
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> The purpose of this server is to support people when they run into issues doing our curriculum. This allows our volunteers to know the exact scope of your problem and correct any poor advice. In addition, this limited scope helps us identify areas in our curriculum that we need to improve.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not ask for advice/help on homework or personal projects, even if the topic is covered by our curriculum. Instead, research other servers/communities that offer general programming help.
+
+### Ask questions about the tools recommended in our curriculum
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> This community is run by the same volunteers who maintain the curriculum and they created this server as a way to support people when they run into issues with our recommendations.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not suggest tools that are outside of the curriculum's recommendations, such as using Windows, WSL, etc, because our committed volunteers are not equipped to support these additional tools. You are welcome to use them, but do not suggest them to others.
+
+### Ask questions in public channels for anyone to answer
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Ask questions in public channels because everyone in this community shares the responsibility to answer questions and others can learn from reading the conversation. It is unfair to expect specific people to answer your question.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not send direct messages, friend requests, or ping another user without prior consent.
+
+### Ask your question in only one channel
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> After asking your question in one channel, allow at least 30 minutes for a reply. While you are waiting, make sure that you posted in the most relevant channel, provided a detailed question, and continue trouble-shooting. It is recommended to edit your post with the results of things you have tried. If your post gets buried, you may repost your question, otherwise, you may direct people to your question in a more active channel.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not post the same question in multiple channels.
+
+### Help others by guiding them to the solution in a public 1:1 conversation
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Our community values guiding a person to the solution because it empowers them with more practical skills to apply the next time they run into a problem.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not provide the answer or intrude into a public 1:1 conversation with a different answer. If the guidance is incorrect, you may politely state that there might be some confusion and ask permission to help clarify the issue.
+
+### Make it easy for others to help you by asking a detailed question
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Ask detailed questions by following our [How to Ask Technical Questions](https://www.theodinproject.com/guides/community/how_to_ask) guide. Since your post will be fairly long, use shift + enter to add new lines between paragraphs. A detailed question should contain the following elements:
+
+- Link to the lesson/project in the curriculum
+- Your current code or pseudo code
+- Explain the issue/problem
+- Describe what you are expecting
+- Summarize what you have tried
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Avoid asking low effort questions because it puts too much responsibility on others to properly guide you to the answer. For example:
+
+- Not providing enough details or context
+- Asking questions that can be easily googled or not doing your own research first
+- Posting multiple short messages in rapid succession because they are often incomplete sentences that make it hard for others understand the full situation.
+
+**We take this rule very seriously because repeatedly asking low effort questions causes a drain on our community of volunteers.**
+
+### Share resources that are relevant to our curriculum
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> When sharing resources that are relevant to our curriculum, add surrounding context, such as where you are in the curriculum, what exactly you found helpful, a code example, etc. Remember that our curriculum is open source, so you are encouraged to make a pull request to add it to the curriculum.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> The following resources are not relevant to our curriculum and should not be posted. If you have extraordinary circumstances that you would like to be considered, you are welcome to message ModMail for permission:
+
+- Link to a resource you created for personal or monetary gain
+- Request to have people fill out a survey
+- Link to join another server/community
+- Articles or blog posts on unrelated topics/languages
+- Fundraising or donation drives
+- Job posts or recruitment
+
+### Report misconduct to ModMail
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> Use Modmail to report misconduct, private harassment by a community member, or if anyone makes you or others feel unsafe, uncomfortable, or unwelcome in our community.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> Do not correct or confront another user about their misconduct. We know you mean well, but this will often make the situation worse.
+
+### Act professionally and treat everyone with respect
+<span class="fa-regular fa-circle-check mr-2 text-green-700"></span> The culture of this community is very similar to the professional workplace messaging apps of our volunteer team. Learning how to respectfully interact with others from around the world will prepare you to interact with your future teammates.
+
+<span class="fa-solid fa-triangle-exclamation mr-2 text-amber-600"></span> We have zero tolerance for disrespect. Therefore, the following behaviors will result in a ban from our server:
+
+- Bigotry, such as racism, homophobia, hate speech, etc
+- NSFW or other highly offensive images in posts, profile pictures, or username
+- Spamming multiple channels with the same or nonsensical messages (copypasta)
+- Disrespectful or targeted harassment, directed insults, naming & shaming
+- Aggressive arguments
+- Inciting drama, provoking/baiting other users, passive aggression
+- Unsolicited self-promotion
+- Piracy, links to pirated material, suggesting pirating intellectual property
+- Plagiarism
+- Doxxing
+- Trolling
+- Publicly arguing about receiving moderation after being asked to discuss privately through ModMail
+- Any other behavior deemed unacceptable and deserving of a ban by the moderation team, such as displaying a pattern of breaking our rules


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The rules currently reside on an [erb file in the main site](https://github.com/TheOdinProject/theodinproject/blob/main/app/views/guides/community/rules.html.erb). This makes it more difficult for tools (like the odin-bot) to interact with the rules. Transferring to a Markdown document will make the rules easier to parse programmatically. See the associated issue for more information about this.
## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds the rules in a markdown file
- Preserves the icon stylings that are currently on the page for the main site.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
[Issue on Main Site repo](https://github.com/TheOdinProject/theodinproject/issues/4022)

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
I left in the font-awesome icons. I like the way these look on the site, but they won't render properly in a plain Markdown file. Maybe it's better to get rid of them?

I also didn't give a ton of thought to the name of this file (`community-rules.md`) or its position in the directory structure of this repo. Will gladly take any thoughts on that.
