### PR TITLE
Update community-rules.md to include memes

### DIFF
--- a/community-rules.md
+++ b/community-rules.md
@@ -28,7 +28,7 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Ask your question in multiple channels
 - Intrude into a public 1:1 conversation by providing a different answer
 - Avoid asking low effort questions that are missing relevant details
-- Share resources that are not relevant to our curriculum
+- Share resources that are not relevant to our curriculum. This includes memes
 - Correct or confront another user about their misconduct
 - Act unprofessionally or treat anyone disrespectfully
 

--- a/community-rules.md
+++ b/community-rules.md
@@ -28,7 +28,6 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Ask your question in multiple channels
 - Intrude into a public 1:1 conversation by providing a different answer
 - Avoid asking low effort questions that are missing relevant details
-- Share resources that are not relevant to our curriculum. This includes memes
 - Correct or confront another user about their misconduct
 - Act unprofessionally or treat anyone disrespectfully
 
@@ -106,6 +105,7 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Articles or blog posts on unrelated topics/languages
 - Fundraising or donation drives
 - Job posts or recruitment
+- Memes, even if they are programming-related. It is acceptable to reply in a conversation with a relevant gif.
 
 [rule-name]: # (modmail)
 


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
We don't have a meme channel so people often resort to any non-specific channel to still share them, like bot-spam, off-topic (which includes no-memes in the description but it still happens), club-40 etc. 

I think this needs to be more explicitly mentioned to avoid confusion for community members and avoid moderators having to keep repeating that it's not something we want to see in our server, without a sufficiently specific rule backing it up. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- adds memes explicitly as part of non-relevant resources

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

