### PR TITLE
Feature: Use actual markdown headers for FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,4 +1,4 @@
-###Start here:
+### Start here:
 
 [FAQ](https://www.theodinproject.com/faq)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,4 +1,4 @@
-**Start here:**
+###Start here:
 
 [FAQ](https://www.theodinproject.com/faq)
 
@@ -10,109 +10,109 @@
 
 [How to Ask Technical Questions](https://www.theodinproject.com/guides/community/how_to_ask)
 
-**==== FEATURED QUESTION ====**
+### ==== FEATURED QUESTION ====
 
 [Why can't I use Windows?](https://discord.com/channels/505093832157691914/690588860085960734/828714982253789215)
 
-**=========================**
+### =========================
 
 
-**What does "TOP" mean?**
+### What does "TOP" mean?
 
 TOP is the abbreviation for The Odin Project
 
-**Can TOP help get me a job?**
+### Can TOP help get me a job?
 
 We do not offer job services. However, if you have completed TOP, you have the skills and qualifications needed to find a job. See <#669547324707569665> and the [getting hired section of the curriculum](https://www.theodinproject.com/paths/full-stack-javascript/courses/getting-hired) for advice on the job search. <#1013804065169346631> are also a good source of motivation.
 
-**Does TOP give certificates?**
+### Does TOP give certificates?
 
 No, certificates do not have much value outside of very small niches in IT, usually not programming. After TOP, your portfolio should speak for itself
 
-**When should I use ModMail?**
+### When should I use ModMail?
 
 If you see anything in the server that you believe is against our community rules, we encourage you to send a DM to <@575252669443211264> and to not address the issue yourself. You can also send a DM to <@575252669443211264> if you're not sure if you're allowed to share something in our channels. You can find more info about how to use ModMail in the [guide we posted here](https://discord.com/channels/505093832157691914/1059513837197459547/1082300847716835341).
 
-**When should I NOT use ModMail?**
+### When should I NOT use ModMail?
 
 Please don't use <@575252669443211264> for personal TOP advice, programming help or casual chats with the team.
 
-**Can I post my affiliate links, self promote, advertise my server/product here?**
+### Can I post my affiliate links, self promote, advertise my server/product here?
 
 Almost always no. Do not assume you have permission. We may entertain things that are not designed to make money or take away from the mission of TOP. Please ask us in a DM to <@575252669443211264>.
 
-**How long does TOP take?**
+### How long does TOP take?
 
 There is no data on this information, between 3 months and 3 years seems to be the range. Read this [great message about the time it may or may not take](https://discord.com/channels/505093832157691914/505093832157691916/765633002393829389) for more info.
 
-**Can I contribute?**
+### Can I contribute?
 
 Of course, check out [our Github](https://github.com/TheOdinProject) and follow the contributing guide.
 
-**What is Thinkful and their relationship to TOP?**
+### What is Thinkful and their relationship to TOP?
 
 In the past, Thinkful paid our hosting costs in exchange for an advertisement. They did not use our curriculum, nor do they contribute to ours. TOP is fully run by the Core and Maintainer teams, as well as other contributors on a volunteer basis.
 
-**Are you affiliated with "_ bootcamp"?**
+### Are you affiliated with "_ bootcamp"?
 
 We are not currently affiliated with any bootcamps. Our license prohibits the use of our curriculum when there are any fees charged. So if you hear about one that is using our material, please let us know through <@575252669443211264>.
 
-**Does TOP teach Python or any other language?**
+### Does TOP teach Python or any other language?
 
 Visit [our website](https://www.theodinproject.com) to see what is covered, and also read this [message on learning programming instead of specific programming languages](https://discord.com/channels/505093832157691914/505093832157691916/739908597873508454).
 
-**Which path should I take? / What language should I learn?**
+### Which path should I take? / What language should I learn?
 
 It doesn't matter, though there's more information at the end of Foundations. Don't worry until you have completed Foundations. See above.
 
-**In what order should I take the courses of the curriculum?**
+### In what order should I take the courses of the curriculum?
 
 You should start at the beginning and not skip, even if you feel you are experienced. Part of what makes TOP work is building on previous knowledge in the curriculum. If you know the stuff, it will go quickly, if you do not, you'll be glad you did it. TOP expects you to have gone through the previous sections before each next section. This is a curriculum, not a collection of tutorials.
 
-**Should I take notes?**
+### Should I take notes?
 
 Mostly, no. Understanding > memorization. This [message on note-taking](https://discord.com/channels/505093832157691914/505093832157691916/768161823366578176) is a great read on the topic.
 
-**Do I need a degree to get a job?**
+### Do I need a degree to get a job?
 
 Generally no, however a degree can help you get past some non-understanding HR people. Many people have become successful without them, see <#1013804065169346631>.
 
-**Should I do multiple courses at the same time?**
+### Should I do multiple courses at the same time?
 
 We strongly advise against this. For more context on our opinion, read this [message on doing multiple courses at the same time](https://discord.com/channels/505093832157691914/505093832157691916/778727680438698055).
 
-**Is there an Odin dark theme?**
+### Is there an Odin dark theme?
 
 Yup! If you are not logged in, you will see a little moon and sun icon in the top nav bar. If you are logged in, you will see the choice when you click on the user icon in the top nav bar.
 
-**Is TOP hard?**
+### Is TOP hard?
 
 Very, but that doesn't mean you can't do it. Learning programming in general is tough, no matter where you go. In order to get through it, you'll need to develop [grit](https://www.ted.com/talks/angela_lee_duckworth_grit_the_power_of_passion_and_perseverance)
 
-**Does the TOP staff get paid?**
+### Does the TOP staff get paid?
 
 Nope, this is run by the community, for the community without pay of any sort.
 
-**How can I help others solve their coding problems?**
+### How can I help others solve their coding problems?
 
 Read our [guide on helping others solve coding problems](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/join-the-odin-community#how-to-help-others-solve-coding-problems).
 
-**How should I ask questions?**
+### How should I ask questions?
 
 [Read this](https://www.theodinproject.com/guides/community/how_to_ask).
 
-**What books should I read/do you recommend?**
+### What books should I read/do you recommend?
 
 Our curriculum will recommend books when the time is right. If you haven't come across recommendations, the time isn't right. Yet. (Though, we've heard Moby Dick is a good book.)
 
-**How can I get the "professional" role?**
+### How can I get the "professional" role?
 
 The "professional" role is limited to those who are verified industry professionals such as software engineers, software developers, web developers, and other associated software development team roles. Please fill out this [form to apply for the professional role](https://dyno.gg/form/ad2fdb2f).
 
-**What is the "studying" voice channel?**
+### What is the "studying" voice channel?
 
 It's just a way to show off that you're studying! Think of it like going to a library and studying quietly.
 
-**Can I translate your curriculum to another language?**
+### Can I translate your curriculum to another language?
 
 Possibly. There are certain [limitations and concerns](https://github.com/TheOdinProject/blog/wiki/What-about-translations-of-your-curriculum) that you need to consider.


### PR DESCRIPTION
## Because
- Discord supports proper markdown headers, instead of just bolding the "headers". This has a few advantages:
 -  Looks cleaner, both on Discord and when working with the `.md` file
 - Makes it a lot easier to distinguish sections (ref TheOdinProject/odin-bot-v2#456)


## This PR
- Changes the bold headers to h3 markdown headers

## Screenshot
![image](https://github.com/TheOdinProject/top-meta/assets/76259120/0953053f-8397-4d69-82f3-076f5da32898)
