### PR TITLE
Rules: remove incorrect double negative

### DIFF
--- a/community-rules.md
+++ b/community-rules.md
@@ -27,7 +27,7 @@ When a rule has been broken, the moderators will assume everyone had positive in
 - Send direct messages, friend requests, or ping another user without prior consent
 - Ask your question in multiple channels
 - Intrude into a public 1:1 conversation by providing a different answer
-- Avoid asking low effort questions that are missing relevant details
+- Ask low effort questions that are missing relevant details
 - Share resources that are not relevant to our curriculum
 - Correct or confront another user about their misconduct
 - Act unprofessionally or treat anyone disrespectfully


### PR DESCRIPTION
## Because
The rules in their current state could be interpreted to say that users should not avoid asking bad questions

## This PR
Removes the negative

## Issue
Closes #305