### PR TITLE
Update maintainer onboarding doc

### DIFF
--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -6,7 +6,7 @@ Maintainers are representatives of The Odin Project community who assist with th
 
 ## Settings
 
-- Please ensure you have 2FA authentication enabled so if a situation arises in which you need to moderate you will be able to do so. You can find the [discord guide for 2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
+- Please ensure you have 2FA authentication enabled so if a situation arises in which you need to moderate you will be able to do so. You can use the [discord guide for 2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
 
 - You should ensure you have 2FA authentication enabled for Github to keep your account secure. _Please ensure you follow the [GitHub guide for 2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)_ to ensure you set it up properly.
 

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -32,8 +32,6 @@ Being that contributions will vary in substance and frequency, the Core team wil
   - Adding a checklist for definition of "success" for whoever takes the issue
   - Suggestions on possible solutions
 - **Ask for contributions in the #contributions-opportunities channel**
-  - Do not go overboard, people don't like getting pinged a lot
-  - Consider batching requests in one ping
 - **Assign issues to those claiming it** (Check the right side of the page on an open issue)
   - People should comment on the issue they are working on the issue
 - **Moving issues to the proper section on the project board** (Check the right side of the page on an open issue)

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -81,3 +81,14 @@ Being that contributions will vary in substance and frequency, the Core team wil
 - Subscribe to the group Google Calendar (link pinned in the maintainer-discussions channel of the discord)
 - Meetings are generally held twice a month
 - Attendance is not _required_ but is strongly encouraged whenever you're able to attend.
+
+## Burnout
+
+Try to keep the following in mind.
+
+1. Be mindful of your feelings. If you feel like being a maintainer is becoming a chore, express this to your team and discuss what you can do to feel better - whether that's taking a small break, taking on less work, or approaching being a maintainer differently.
+1. Don't watch over the GitHub repos like a hawk. Find a balance in your life, in and outside of The Odin Project responsibilities. Set rules for yourself to stay healthy, happy, and stick to those rules.
+1. This should go without saying but is worth re-iterating: you're not alone, there's nothing to prove, and there's an entire team here to support you. Take time easing into your new role, and lean on your team for support.
+1. At the end of every week make some time to take a step back and assess how the week of being a maintainer went for you. How are you feeling? Have you been involved in TOP less than usual or more than usual? Are there things you're proud of?
+1. Encourage yourself and your fellow maintainers to take more breaks. Your health and happiness always come first before TOP.
+1. Say thank you. Show appreciation for your fellow maintainers, these two small words can make a big difference in a person's day.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -77,7 +77,6 @@ Being that contributions will vary in substance and frequency, the Core team wil
 
 ### Attend Meetings
 
-- Subscribe to the group Google Calendar (link pinned in the maintainer-discussions channel of the discord)
 - Meetings are generally held twice a month
 - Attendance is not _required_ but is strongly encouraged whenever you're able to attend.
 

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -31,7 +31,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 - **Modify issue contents with more information that could be relevant**
   - Adding a checklist for definition of "success" for whoever takes the issue
   - Suggestions on possible solutions
-- **Ask for contributions in the #contributions-opportunities channel**
+- While not required, consider posting issues that are open for assignment request in the #contributions-opportunities channel, especially if they're straightforward
 - **Assign issues to those claiming it** (Check the right side of the page on an open issue)
   - People should comment on the issue they are working on the issue
 - **Moving issues to the proper section on the project board** (Check the right side of the page on an open issue)

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -39,7 +39,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 - **Moving issues to the proper section on the project board** (Check the right side of the page on an open issue)
   - Curriculum issues should be attached to the 'curriculum' project board
   - Most things will be "backlog" unless it breaks significant parts of the course
-  - When assigned to somebody, issue should be put in "in-progress"
+  - When assigned to somebody, issue should be put in "In progress"
     - Don't be afraid to check up on people working on issues
   - Issues with attached PRs will be closed automatically
 - **Keep an eye on the project board**

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -37,7 +37,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 - **Assign issues to those claiming it** (Check the right side of the page on an open issue)
   - People should comment on the issue they are working on the issue
 - **Moving issues to the proper section on the project board** (Check the right side of the page on an open issue)
-  - Curriculum issues should be attached to the 'curriculum' project board
+  - Curriculum issues should be attached to the "Curriculum Workflow" project board (usually done automatically)
   - Most things will be "backlog" unless it breaks significant parts of the course
   - When assigned to somebody, issue should be put in "In progress"
     - Don't be afraid to check up on people working on issues

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -20,7 +20,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 
 ### Maintain Issues
 
-- A maintainer should spend time maintaining the Github
+- A maintainer should spend time maintaining the repos on GitHub
 - As a maintainer, you should use your discretion on which issues _you_ should take yourself. Part of your goal, is to increase contributions from the entire community
 - **Delete/Close** irrelevant and unhelpful issues and comments
   - **Explain reasoning for closing issue**

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -64,7 +64,6 @@ Being that contributions will vary in substance and frequency, the Core team wil
   - Since you are a maintainer, we trust your judgement. With git, everything can be reverted, so don't be afraid to merge things from non-maintainers/core.
     - Ask Kevin about his screw-ups (and Marvin)
   - If a PR looks to be good, feel free to merge after review.
-    - When a maintainer submits a PR, you only need to review it. After your approval, they will merge it in themselves.
   - Do not merge if you are unsure, ask somebody else for review.
     - If no one has reviewed the PR, you are welcome to post it in the #review-requests channel to bring it to everyone's attention.
     - If the contributor has made the requested changes without requesting another review, you should request it for them on GitHub.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -82,7 +82,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 
 ## Burnout
 
-Try to keep the following in mind.
+Try to keep the following in mind:
 
 1. Be mindful of your feelings. If you feel like being a maintainer is becoming a chore, express this to your team and discuss what you can do to feel better - whether that's taking a small break, taking on less work, or approaching being a maintainer differently.
 1. Don't watch over the GitHub repos like a hawk. Find a balance in your life, in and outside of The Odin Project responsibilities. Set rules for yourself to stay healthy, happy, and stick to those rules.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -62,7 +62,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 - **Merge PRs**
   - All maintainers share the responsibility of reviewing and merging PRs, even if another maintainer requested changes or created the issue (with the exception of a specialized epic project that one maintainer is overseeing).
   - Since you are a maintainer, we trust your judgement. With git, everything can be reverted, so don't be afraid to merge things from non-maintainers/core.
-    - Ask Kevin about his screw-ups (and Marvin)
+    - Ask Kevin about his screw-ups
   - If a PR looks to be good, feel free to merge after review.
   - Do not merge if you are unsure, ask somebody else for review.
     - If no one has reviewed the PR, you are welcome to post it in the #review-requests channel to bring it to everyone's attention.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -27,7 +27,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
   - Before deletion, ask for more info if issue could be viable
   - People asking for help on projects, should be directed to the forum or chat before deletion
 - **Add tags to issues as applicable** (Check the right side of the page on an open issue)
-  - e.g. "First Time Only" (for super easy issues, to help gain more contributors)
+  - e.g. "Help wanted" or "Good first issue" (for super easy issues, to help gain more contributors)
 - **Modify issue contents with more information that could be relevant**
   - Adding a checklist for definition of "success" for whoever takes the issue
   - Suggestions on possible solutions

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -64,7 +64,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
   - Since you are a maintainer, we trust your judgement. With git, everything can be reverted, so don't be afraid to merge things from non-maintainers/core.
     - Ask Kevin about his screw-ups
   - If a PR looks to be good, feel free to merge after review.
-  - Do not merge if you are unsure, ask somebody else for review.
+  - Do not merge if you are unsure. Ask somebody else for review.
     - If no one has reviewed the PR, you are welcome to post it in the #review-requests channel to bring it to everyone's attention.
     - If the contributor has made the requested changes without requesting another review, you should request it for them on GitHub.
   - If a PR was made by another maintainer only approve it, don't merge it. On the team we merge our own PRs.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -60,7 +60,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
     - <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews>
   - New lessons will have to have the "seeds" file updated to accommodate and show on the site
 - **Merge PRs**
-  - All maintainers share the responsibility of reviewing and merging PRs, even if another maintainer requested changes or created the issue (with the exception of a specialized epic project that one maintainer is overseeing, like the new HTML/CSS lessons).
+  - All maintainers share the responsibility of reviewing and merging PRs, even if another maintainer requested changes or created the issue (with the exception of a specialized epic project that one maintainer is overseeing).
   - Since you are a maintainer, we trust your judgement. With git, everything can be reverted, so don't be afraid to merge things from non-maintainers/core.
     - Ask Kevin about his screw-ups (and Marvin)
   - If a PR looks to be good, feel free to merge after review.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -14,7 +14,7 @@ Maintainers are representatives of The Odin Project community who assist with th
 
 Maintainers, and those wishing to be considered for the Maintainer role, are expected to have a record of regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.
 
-Being that contributions will vary in substance and frequency, the Core team will determine if the member is meeting the expectations for the Maintainer role. If the expectations are not being met, the member will not be considered for the Maintainer role. If member is currently a Maintainer, they will be moved to Maintainer-Inactive role with the option to return to Maintainer status upon making regular contributions.
+Being that contributions will vary in substance and frequency, the Core team will determine if the member is meeting the expectations for the Maintainer role. If the expectations are not being met, the member will not be considered for the Maintainer role. If member is currently a Maintainer, they will be moved to Maintainer-Inactive role with the option to return to Maintainer status upon rejoining the triage rotation.
 
 ## Github Responsibilities and Guidelines
 

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -14,7 +14,7 @@ Maintainers are representatives of The Odin Project community who assist with th
 
 Maintainers, and those wishing to be considered for the Maintainer role, are expected to have a record of regular and positive contributions to The Odin Project community. Maintainers are expected to make contributions to The Odin Project curriculum and provide support for the Discord server.
 
-Being that contributions will vary in substance and frequency, the Core team will determine if the member is meeting the expectations for the Maintainer role. If the expectations are not being met, the member will not be considered for the Maintainer role. If member is currently a Maintainer, they will be moved to Maintainer-Emeritus role with the option to return to Maintainer status upon making regular contributions.
+Being that contributions will vary in substance and frequency, the Core team will determine if the member is meeting the expectations for the Maintainer role. If the expectations are not being met, the member will not be considered for the Maintainer role. If member is currently a Maintainer, they will be moved to Maintainer-Inactive role with the option to return to Maintainer status upon making regular contributions.
 
 ## Github Responsibilities and Guidelines
 

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -4,11 +4,11 @@
 
 Maintainers are representatives of The Odin Project community who assist with the management of processes on the Github account.
 
-## Settings 
+## Settings
 
-- Please ensure you have 2FA authentication enabled so if a situation arises in which you need to moderate you will be able to do so. You can find the discord guide for 2FA [here](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
+- Please ensure you have 2FA authentication enabled so if a situation arises in which you need to moderate you will be able to do so. You can find the [discord guide for 2FA](https://support.discord.com/hc/en-us/articles/219576828-Setting-up-Two-Factor-Authentication).
 
-- You should ensure you have 2FA authentication enabled for Github to keep your account secure. _Please ensure you follow the guide [here](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)_ to ensure you set up 2FA properly.
+- You should ensure you have 2FA authentication enabled for Github to keep your account secure. _Please ensure you follow the [GitHub guide for 2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)_ to ensure you set it up properly.
 
 ### Admission and Removal of Role
 
@@ -21,63 +21,63 @@ Being that contributions will vary in substance and frequency, the Core team wil
 ### Maintain Issues
 
 - A maintainer should spend time maintaining the Github
-- As a maintainer, you should use your discretion on which issues *you* should take yourself. Part of your goal, is to increase contributions from the entire community
+- As a maintainer, you should use your discretion on which issues _you_ should take yourself. Part of your goal, is to increase contributions from the entire community
 - **Delete/Close** irrelevant and unhelpful issues and comments
-    - **Explain reasoning for closing issue**
-    - Before deletion, ask for more info if issue could be viable 
-    - People asking for help on projects, should be directed to the forum or chat before deletion
+  - **Explain reasoning for closing issue**
+  - Before deletion, ask for more info if issue could be viable
+  - People asking for help on projects, should be directed to the forum or chat before deletion
 - **Add tags to issues as applicable** (Check the right side of the page on an open issue)
-    - e.g. "First Time Only" (for super easy issues, to help gain more contributors)
+  - e.g. "First Time Only" (for super easy issues, to help gain more contributors)
 - **Modify issue contents with more information that could be relevant**
-    - Adding a checklist for definition of "success" for whoever takes the issue
-    - Suggestions on possible solutions
+  - Adding a checklist for definition of "success" for whoever takes the issue
+  - Suggestions on possible solutions
 - **Ask for contributions in the #contributions-opportunities channel**
-    - Do not go overboard, people don't like getting pinged a lot
-    - Consider batching requests in one ping
+  - Do not go overboard, people don't like getting pinged a lot
+  - Consider batching requests in one ping
 - **Assign issues to those claiming it** (Check the right side of the page on an open issue)
-    - People should comment on the issue they are working on the issue
+  - People should comment on the issue they are working on the issue
 - **Moving issues to the proper section on the project board** (Check the right side of the page on an open issue)
-    - Curriculum issues should be attached to the 'curriculum' project board
-    - Most things will be "backlog" unless it breaks significant parts of the course
-        - e.g. Hartl puts his books behind a paywall
-    - When assigned to somebody, issue should be put in "in-progress"
-        - Don't be afraid to check up on people working on issues
-    - Issues with attached PRs will be closed automatically
+  - Curriculum issues should be attached to the 'curriculum' project board
+  - Most things will be "backlog" unless it breaks significant parts of the course
+    - e.g. Hartl puts his books behind a paywall
+  - When assigned to somebody, issue should be put in "in-progress"
+    - Don't be afraid to check up on people working on issues
+  - Issues with attached PRs will be closed automatically
 - **Keep an eye on the project board**
-    - Feel free to follow up with people, but give them ample time
+  - Feel free to follow up with people, but give them ample time
 
 ### Maintain PRs (Pull Requests)
 
 - **Close PRs** that are irrelevant, or clearly unhelpful to the project
-    - e.g. Somebody PRs solutions to any lesson that is to be cloned and filled out
-        - https://github.com/TheOdinProject/javascript-exercises
-    - Be sure to give a reason for closing the PR
+  - e.g. Somebody PRs solutions to any lesson that is to be cloned and filled out
+    - <https://github.com/TheOdinProject/javascript-exercises>
+  - Be sure to give a reason for closing the PR
 - **Attach issues** to the PR that should be closed when the PR is merged (Check the right side of the page on an open PR)
 - **Review thoroughly**
-    - Look very closely at the markdown
-    - Utilize the request changes feature when reviewing code/lesson content
-        - Feel free to fix small typos and wording using the in-browser editor
-        -  https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews
-    - New lessons will have to have the "seeds" file updated to accomodate and show on the site
+  - Look very closely at the markdown
+  - Utilize the request changes feature when reviewing code/lesson content
+    - Feel free to fix small typos and wording using the in-browser editor
+    - <https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews>
+  - New lessons will have to have the "seeds" file updated to accommodate and show on the site
 - **Merge PRs**
-    - All maintainers share the responsibility of reviewing and merging PRs, even if another maintainer requested changes or created the issue (with the exception of a specialized epic project that one maintainer is overseeing, like the new HTML/CSS lessons).
-    - Since you are a maintainer, we trust your judgement. With git, everything can be reverted, so don't be afraid to merge things from non-maintainers/core.
-        - Ask Kevin about his screw-ups (and Marvin)
-    - If a PR looks to be good, feel free to merge after review.
-        - When a maintainer submits a PR, you only need to review it. After your approval, they will merge it in themselves.
-    - Do not merge if you are unsure, ask somebody else for review.
-        - If no one has reviewed the PR, you are welcome to post it in the #review-requests channel to bring it to everyone's attention.
-        - If the contributor has made the requested changes without requesting another review, you should request it for them on GitHub.
-    - If a PR was made by another maintainer only approve it, don't merge it. On the team we merge our own PRs.
+  - All maintainers share the responsibility of reviewing and merging PRs, even if another maintainer requested changes or created the issue (with the exception of a specialized epic project that one maintainer is overseeing, like the new HTML/CSS lessons).
+  - Since you are a maintainer, we trust your judgement. With git, everything can be reverted, so don't be afraid to merge things from non-maintainers/core.
+    - Ask Kevin about his screw-ups (and Marvin)
+  - If a PR looks to be good, feel free to merge after review.
+    - When a maintainer submits a PR, you only need to review it. After your approval, they will merge it in themselves.
+  - Do not merge if you are unsure, ask somebody else for review.
+    - If no one has reviewed the PR, you are welcome to post it in the #review-requests channel to bring it to everyone's attention.
+    - If the contributor has made the requested changes without requesting another review, you should request it for them on GitHub.
+  - If a PR was made by another maintainer only approve it, don't merge it. On the team we merge our own PRs.
 
 ### Participate in the Triage Rotation
 
-  - Related to the above; each maintainer must be part of the triage rotation for moving issues/PRs out of "needs triage" by closing/approving for work/requesting discussion from others on issues and by reviewing or requesting someone to review for PRs.
-  - Each shift on the rotation lasts one week
-  - Swapping your shift with other maintainers is permitted so long as another maintainer is willing to swap with you
-  
+- Related to the above; each maintainer must be part of the triage rotation for moving issues/PRs out of "needs triage" by closing/approving for work/requesting discussion from others on issues and by reviewing or requesting someone to review for PRs.
+- Each shift on the rotation lasts one week
+- Swapping your shift with other maintainers is permitted so long as another maintainer is willing to swap with you
+
 ### Attend Meetings
 
 - Subscribe to the group Google Calendar (link pinned in the maintainer-discussions channel of the discord)
 - Meetings are generally held twice a month
-- Attendance is not *required* but is strongly encouraged whenever you're able to attend.
+- Attendance is not _required_ but is strongly encouraged whenever you're able to attend.

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -39,7 +39,6 @@ Being that contributions will vary in substance and frequency, the Core team wil
 - **Moving issues to the proper section on the project board** (Check the right side of the page on an open issue)
   - Curriculum issues should be attached to the 'curriculum' project board
   - Most things will be "backlog" unless it breaks significant parts of the course
-    - e.g. Hartl puts his books behind a paywall
   - When assigned to somebody, issue should be put in "in-progress"
     - Don't be afraid to check up on people working on issues
   - Issues with attached PRs will be closed automatically

--- a/onboarding/maintainers.md
+++ b/onboarding/maintainers.md
@@ -77,7 +77,7 @@ Being that contributions will vary in substance and frequency, the Core team wil
 
 ### Attend Meetings
 
-- Meetings are generally held twice a month
+- Meetings are generally held every other Saturday (see the "Team Issue Traige" event on Discord for exact dates and times).
 - Attendance is not _required_ but is strongly encouraged whenever you're able to attend.
 
 ## Burnout


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Following the suggestion from when I was on-boarded, that it would a decent idea to review, as a new(ish) team member, the on-boarding docs, I'm doing exactly that and opening a PR for the maintainer on-boarding docs.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Address the markdown lint errors - not strictly needed, but figured might as well
- Add a section talking about burnout and balancing the maintainer role with life obligations - this section is a mirror to the Burnout section of the moderator on-boarding docs (obviously adjusted where needed to fit the maintainer role)
- Replace `Maintainer-Emeritus` with `Maintainer-Inactive` when talking about going inactive in the maintainer role, but having plans to come back to it
- Remove a bullet point saying maintainers merge their own PRs - the fact that maintainers merge their own PRs was mentioned twice, and though I know this rule is super-duper important 😄, I've decided to only keep the one as its own bullet point, and remove the extra superfluous one
- Fix some typos

